### PR TITLE
Bucket param

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ yarn
 ```
 
 ### HSDS requirement
-This service requires a running instance of HSDS configured with the S3 bucket containing the NSRDB Data
+This service requires a running instance of HSDS.  BUCKET_NAME can be set as below, or you can create a bucket as described in the HSDS installation instructions.
+
+For best performance it's desirable that the service run in the AWS uus-west-2 reegion.
 ```
 BUCKET_NAME=nrel-pds-hsds
 AWS_REGION=us-west-2
@@ -47,4 +49,3 @@ For more info, see https://github.com/alexfernandez/loadtest
 - each request for 4 attributes
 - response time for each < 30 seconds
 - request years and attributes randomized across full range
-

--- a/app/constants.js
+++ b/app/constants.js
@@ -22,8 +22,11 @@ const DATASETS = [
   'wind_speed'
 ]
   
-const HSDS_URI = "http://hsds.nsrdb.test",
+// const HSDS_URI = "http://hsds.nsrdb.test",
+const HSDS_URI = "http://hsds.hdf.test",
       HSDS_DOMAIN = '/nrel/nsrdb';
+
+const BUCKET_NAME = 'nrel-pds-hsds';
 
 module.exports = {
   YEARS,
@@ -31,5 +34,6 @@ module.exports = {
   LAST_YEAR: YEARS[YEARS.length-1],
   DATASETS,
   HSDS_DOMAIN,
-  HSDS_URI
+  HSDS_URI,
+  BUCKET_NAME
 }

--- a/app/constants.js
+++ b/app/constants.js
@@ -22,8 +22,7 @@ const DATASETS = [
   'wind_speed'
 ]
   
-// const HSDS_URI = "http://hsds.nsrdb.test",
-const HSDS_URI = "http://hsds.hdf.test",
+const HSDS_URI = "http://hsds.nsrdb.test",
       HSDS_DOMAIN = '/nrel/nsrdb';
 
 const BUCKET_NAME = 'nrel-pds-hsds';

--- a/app/index.route.js
+++ b/app/index.route.js
@@ -9,6 +9,7 @@ const express = require('express'),
 
 const hsdsUri = constants.HSDS_URI;
       hsdsDomain = constants.HSDS_DOMAIN,
+      bucket = constants.BUCKET_NAME,
       apiKey = constants.API_KEY,
       router = express.Router();
 
@@ -80,8 +81,9 @@ async function(req, res, next){
       let dsId = datasetMeta.datasets.find(dsm => dsm.name === ds)['id'],
           requestUri = `${hsdsUri}/datasets/${dsId}/value`,
           params = {
-            host: `${hsdsDomain}/nsrdb_${year}.h5`,
-            select: selectParm
+            domain: `${hsdsDomain}/nsrdb_${year}.h5`,
+            select: selectParm,
+            bucket: `${bucket}`
           },
           options = {
             uri: requestUri,

--- a/app/utils.js
+++ b/app/utils.js
@@ -12,7 +12,8 @@ const _initNSRDBMetaForAttr = function(year, dataset, attr, axiosInstance) {
     // Fifth get the value of each available attribute
     let axiosOpts = {
       params: {
-        host: `${constants.HSDS_DOMAIN}/nsrdb_${year}.h5`
+        domain: `${constants.HSDS_DOMAIN}/nsrdb_${year}.h5`,
+        bucket: `${constants.BUCKET_NAME}`
       },
       url: `/datasets/${dataset.id}/attributes/${attr.name}`
     };
@@ -35,7 +36,8 @@ const _initNSRDBMetaForDataset = function (year, dataset, axiosInstance) {
   const req = function (callback) {
     let axiosOpts = {
       params: {
-        host: `${constants.HSDS_DOMAIN}/nsrdb_${year}.h5`
+        domain: `${constants.HSDS_DOMAIN}/nsrdb_${year}.h5`,
+        bucket: `${constants.BUCKET_NAME}`
       },
       url: `/datasets/${dataset.id}/attributes`
     };
@@ -62,7 +64,8 @@ const _initNSRDBMetaForYear = function(year, axiosInstance) {
     let meta = {},
         axiosOpts = {
           params: {
-            host: `${constants.HSDS_DOMAIN}/nsrdb_${year}.h5`
+            domain: `${constants.HSDS_DOMAIN}/nsrdb_${year}.h5`,
+            bucket: `${constants.BUCKET_NAME}`
           }
         };
 


### PR DESCRIPTION
I've added a param to the requests so that the bucket can be specified.  This allows an existing HSDS instance to read data from the nrel-pds-hsds bucket.

yarn start is able to fetch the metadata, but I'm seeing an error with yarn ltest:
```
$ yarn ltest
yarn run v1.16.0
$ node loadtest.js
[Fri Jul 05 2019 09:36:44 GMT-0700 (Pacific Daylight Time)] ERROR Invalid timeout 0
[Fri Jul 05 2019 09:36:44 GMT-0700 (Pacific Daylight Time)] ERROR Invalid timeout 0
[Fri Jul 05 2019 09:36:44 GMT-0700 (Pacific Daylight Time)] ERROR Invalid timeout 0
[Fri Jul 05 2019 09:36:44 GMT-0700 (Pacific Daylight Time)] ERROR Invalid timeout 0
[Fri Jul 05 2019 09:36:44 GMT-0700 (Pacific Daylight Time)] ERROR Invalid timeout 0
[Fri Jul 05 2019 09:36:44 GMT-0700 (Pacific Daylight Time)] ERROR Invalid timeout 0
----
/Users/jreadey/NREL/hsds-nsrdb-test/loadtest.js:12
  console.log('Request elapsed milliseconds: ', result.requestElapsed);
                                                       ^

TypeError: Cannot read property 'requestElapsed' of undefined
    at Object.statusCallback (/Users/jreadey/NREL/hsds-nsrdb-test/loadtest.js:12:56)
    at Operation.callback (/Users/jreadey/NREL/hsds-nsrdb-test/node_modules/loadtest/lib/loadtest.js:132:17)
    at /Users/jreadey/NREL/hsds-nsrdb-test/node_modules/loadtest/lib/httpClient.js:227:19
    at ClientRequest.request.on.error (/Users/jreadey/NREL/hsds-nsrdb-test/node_modules/loadtest/lib/httpClient.js:190:4)
    at ClientRequest.emit (events.js:182:13)
    at Socket.socketErrorListener (_http_client.js:391:9)
    at Socket.emit (events.js:182:13)
    at emitErrorNT (internal/streams/destroy.js:82:8)
    at emitErrorAndCloseNT (internal/streams/destroy.js:50:3)
    at process._tickCallback (internal/process/next_tick.js:63:19)
error Command failed with exit code 1.
```

Any idea as to what's going on?  I don't see anyplace where timeout should be set.